### PR TITLE
add Woorimail SPF_DKIM

### DIFF
--- a/tpl/js/config.js
+++ b/tpl/js/config.js
@@ -23,7 +23,8 @@
 			"mailgun" : ["include:mailgun.org", "mailo._domainkey"],
 			"mandrill" : ["include:spf.mandrillapp.com", "mandrill._domainkey"],
 			"postmark": ["include:spf.mtasv.net", "********.pm._domainkey"],
-			"sendgrid" : ["include:sendgrid.net", "smtpapi._domainkey"]
+			"sendgrid" : ["include:sendgrid.net", "smtpapi._domainkey"],
+			"woorimail" : ["include:woorimail.com", ""]
 		};
 		
 		var reset_spf_dkim = function() {


### PR DESCRIPTION
자기 메일 주소를 사용하려면 SPF만 DNS TXT 에 인클루드 해주면 되며, DKIM 은 wms.woorimail.com 의 설정을 그대로 승계하여 사용합니다.